### PR TITLE
Correct indent for job template labels

### DIFF
--- a/charts/elasticsearch-curator/templates/cronjob.yaml
+++ b/charts/elasticsearch-curator/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
         app: {{ template "elasticsearch-curator.name" . }}
         release: {{ .Release.Name }}
         {{- if .Values.cronjob.labels }}
-        {{ toYaml .Values.cronjob.labels | nindent 12 }}
+        {{ toYaml .Values.cronjob.labels | nindent 8 }}
         {{- end }}
     spec:
       template:


### PR DESCRIPTION
Fix #12 - Indent for `.spec.jobTemplate.metadata.labels` corrected to be 8 instead of 12.